### PR TITLE
Check if edit relates to existing endpoint

### DIFF
--- a/sixnines.rb
+++ b/sixnines.rb
@@ -344,8 +344,9 @@ post '/a/add' do
 end
 
 post '/a/edit' do
-  unless settings.base.endpoints(@locals[:user][:login]).include?(params[:old])
-    raise "Invalid endpoint \"#{params[:old]}\""
+  endpoints_uri_list = settings.base.endpoints(@locals[:user][:login]).list.map{|e| e.to_h[:uri].to_s}
+  if not endpoints_uri_list.include?(params[:old])
+    raise "Can't edit unknown endpoint \"#{params[:old]}\""
   end
 
   settings.base.endpoints(@locals[:user][:login]).del(params[:old])

--- a/sixnines.rb
+++ b/sixnines.rb
@@ -343,10 +343,11 @@ post '/a/add' do
   redirect to('/a')
 end
 
-# @todo #93:30min We should check that there were no successful pings before
-#  changing the endpoint to ensure no one uses this feature to register new
-#  sites without charge.
 post '/a/edit' do
+  unless settings.base.endpoints(@locals[:user][:login]).include?(params[:old])
+    raise "Invalid endpoint \"#{params[:old]}\""
+  end
+
   settings.base.endpoints(@locals[:user][:login]).del(params[:old])
   settings.base.endpoints(@locals[:user][:login]).add(params[:new])
   redirect to('/a')


### PR DESCRIPTION
Hey there!

There is note in `sixnines.rb` file about possibility to create new endpoint without payment:
https://github.com/yegor256/sixnines/blob/8bdbd70/sixnines.rb#L346-L353

I was able to reproduce this by using following request:
```bash
http --form POST https://www.sixnines.io/a/edit \
  'Cookie:glogin=3YBx....jYvJ' \
  old='https://example.org' \
  new='https://agrrh.com'
```

Result is new endpoint was created:
![Screenshot from 2020-04-18 22-24-07](https://user-images.githubusercontent.com/1294495/79669521-c3657200-81c4-11ea-9c0f-05e55dd97a28.png)

BTW, I was trying to remove endpoint afterwards, but it stays there w/o any error messages. Feel free to wipe my account.