### PR TITLE
#198: Accept apt release-info changes in Rultor

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -12,7 +12,7 @@ assets:
   id_rsa.pub: yegor256/home#assets/heroku-key.pub
 install: |-
   sudo gem install openssl -- --with-openssl-dir=/usr/local/rvm/rubies/ruby-3.0.1/lib/ruby/3.0.0/openssl
-  sudo apt-get update -y
+  sudo apt-get update -y --allow-releaseinfo-change
   sudo apt-get install --yes libmagickwand-dev imagemagick
   pdd -f /dev/null
   sudo bundle install --no-color "--gemfile=$(pwd)/Gemfile"


### PR DESCRIPTION
/claim #198
Fixes #198

## Summary

- Allows the Rultor install step to accept apt repository release-info changes during `apt-get update`.
- Keeps the rest of the install and merge script unchanged.
- Targets the failure seen in `#196` and `#197`, where Rultor stops before the project build because the `ondrej/php` PPA label changed.

## Validation

- `ruby -e "require 'yaml'; YAML.load_file('.rultor.yml'); puts 'yaml-ok'"` -> `yaml-ok`.
- `git diff --check` -> clean.
- `git diff --no-ext-diff | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found.
- `docker run --rm ruby:3.3 bash -lc 'apt-get update -y --allow-releaseinfo-change >/tmp/apt.out && echo update-ok'` -> `update-ok`.

No wallet, payout, signing, production mutation, or destructive action was performed.
